### PR TITLE
Fix Project functions for Organization Feature

### DIFF
--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -9,7 +9,6 @@ import {
   UseGuards,
   Req,
   Query,
-  Headers,
   BadRequestException,
 } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
@@ -23,10 +22,7 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import { RolesGuard } from '../auth/guards/roles.guard';
-import { Role } from '../auth/enums/role.enum';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { RequestMetadata } from 'src/common/request-metadata/request-metadata.decorator';
-import { RequestMetadataDto } from 'src/common/request-metadata/request-metadata.dto';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { WorksheetService } from '../tracker/worksheet.service';
 import { WorksheetListOfProjectQueryDto } from './dto/worksheet-list-of-project.query.dto';
@@ -168,49 +164,48 @@ export class ProjectsController {
     );
   }
 
-  @UseGuards(RolesGuard)
-  @UseGuards(AccessTokenGuard)
+  @Auth()
   @ApiBearerAuth()
-  @Roles(['Admin', 'Member'])
   @Get('names')
-  findProjectNames(
-    @Req() req: Request,
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10,
-  ) {
-    console.log(`USERID: ${req['user'].userId}`);
-    return this.projectsService.getNames(+page, +limit, req['user'].userId);
+  findProjectNames(@Req() req: Request) {
+    return this.projectsService.getNames(
+      req['user'].userId,
+      req['user'].organizationId,
+    );
   }
-  @UseGuards(AccessTokenGuard)
+
+  @Auth(['admin'])
   @ApiBearerAuth()
-  @Roles(['Admin'])
-  @UseGuards(RolesGuard)
   @Post()
   create(@Body() createProjectDto: CreateProjectDto, @Req() req: Request) {
-    return this.projectsService.create(createProjectDto, req['user'].userId);
+    return this.projectsService.create(createProjectDto, req['user'].userId, req['user'].organizationId);
   }
-  @UseGuards(AccessTokenGuard)
+
+  @Auth()
   @ApiBearerAuth()
-  @Roles(['Admin', 'Member'])
-  @UseGuards(RolesGuard)
   @Get()
   findAll(
     @Req() req: Request,
     @Query('page') page: number = 1,
     @Query('limit') limit: number = 10,
   ) {
-    return this.projectsService.findAll(+page, +limit, req['user'].userId);
-  }
-
-  @Auth()
-  @ApiBearerAuth()
-  @Get('get-user-projects-by-organization')
-  async getUserProjectsByOrganization(@Req() req: Request) {
-    return await this.projectsService.getUserProjectsByOrganization(
+    return this.projectsService.findAll(
+      +page,
+      +limit,
       req['user'].userId,
       req['user'].organizationId,
     );
   }
+
+  // @Auth()
+  // @ApiBearerAuth()
+  // @Get('get-user-projects-by-organization')
+  // async getUserProjectsByOrganization(@Req() req: Request) {
+  //   return await this.projectsService.getUserProjectsByOrganization(
+  //     req['user'].userId,
+  //     req['user'].organizationId,
+  //   );
+  // }
 
   @UseGuards(AccessTokenGuard)
   @ApiBearerAuth()

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -3,14 +3,15 @@ import {
   ConflictException,
   Injectable,
   InternalServerErrorException,
+  Logger,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
-import { InjectModel } from '@nestjs/mongoose';
+import { InjectConnection, InjectModel } from '@nestjs/mongoose';
 import { Project } from '../../schemas/Project.schema';
-import { isValidObjectId, Model, Types } from 'mongoose';
+import { Connection, isValidObjectId, Model, Types } from 'mongoose';
 import { Tool } from '../../schemas/Tool.schema';
 import { ProjectTool } from '../../schemas/ProjectTool.schema';
 import { Organization } from '../../schemas/Organization.schema';
@@ -23,60 +24,100 @@ export class ProjectsService {
   constructor(
     @InjectModel(Project.name) private readonly projectModel: Model<Project>,
     @InjectModel(Tool.name) private readonly toolModel: Model<Tool>,
-    @InjectModel(ProjectTool.name)
-    private readonly ProjectTool: Model<ProjectTool>,
-    @InjectModel(Organization.name)
-    private readonly Organization: Model<Organization>,
+    // @InjectModel(ProjectTool.name)
+    // private readonly ProjectTool: Model<ProjectTool>,
+    @InjectConnection()
+    private readonly connection: Connection,
     @InjectModel(OrganizationProjectUser.name)
     private readonly OrganizationProjectUser: Model<OrganizationProjectUser>,
-    private readonly organizationService: OrganizationService,
+    // private readonly organizationService: OrganizationService,
   ) {}
+  private readonly logger = new Logger(ProjectsService.name);
 
-  async create(createProjectDto: CreateProjectDto, userId: string) {
-    const project = await this.projectModel.findOne({
-      name: createProjectDto.name,
-    });
-    if (project) {
-      throw new ConflictException('Project with this name already exists');
-    }
-    const organization = await this.Organization.find({
-      users: { $in: [userId] },
-    });
-    if (organization.length === 0) {
-      throw new NotFoundException('No organization found for the user');
-    }
-    const tools = await this.toolModel.insertMany(createProjectDto.tools);
-    const projectModel = await this.projectModel.findOneAndUpdate(
-      { name: createProjectDto.name }, // Find project by name (or another unique field)
-      {
-        $set: {
-          tools: tools, // Always update tools
+  async create(
+    createProjectDto: CreateProjectDto,
+    userId: string,
+    organizationId: string,
+  ) {
+    const session = await this.connection.startSession();
+    session.startTransaction();
+
+    try {
+      const existing = await this.projectModel.findOne(
+        { name: createProjectDto.name },
+        null,
+        { session },
+      );
+
+      if (existing) {
+        throw new ConflictException('Project with this name already exists');
+      }
+
+      const tools = await this.toolModel.insertMany(createProjectDto.tools, {
+        session,
+      });
+
+      const project = await this.projectModel.findOneAndUpdate(
+        { name: createProjectDto.name },
+        {
+          $set: {
+            tools: tools,
+          },
+          $setOnInsert: {
+            name: createProjectDto.name,
+            createdBy: new Types.ObjectId(userId),
+          },
         },
-        $setOnInsert: {
-          name: createProjectDto.name,
-          createdBy: new Types.ObjectId(userId),
+        {
+          session,
+          new: true,
+          upsert: true,
         },
-        $push: { assignedUsers: new Types.ObjectId(userId) }, // Avoid conflict with $setOnInsert
-      },
-      { new: true, upsert: true }, // `upsert: true` creates if not exists
-    );
-    await this.Organization.updateOne(
-      { _id: organization[0]._id },
-      { $push: { projects: projectModel } },
-    );
-    await this.OrganizationProjectUser.create({
-      organization: organization[0]._id,
-      project: projectModel,
-      user: new Types.ObjectId(userId),
-    });
-    return projectModel;
+      );
+
+      await this.OrganizationProjectUser.create(
+        [
+          {
+            organization: new Types.ObjectId(organizationId),
+            project: project._id,
+            user: new Types.ObjectId(userId),
+          },
+        ],
+        { session },
+      );
+
+      await session.commitTransaction();
+      return project;
+    } catch (error) {
+      await session.abortTransaction();
+
+      if (error instanceof ConflictException) {
+        throw error;
+      }
+
+      this.logger.error('Project creation failed', {
+        userId,
+        organizationId,
+        error: error.message,
+      });
+
+      throw new InternalServerErrorException('Failed to create project');
+    } finally {
+      session.endSession();
+    }
   }
 
-  async findAll(page: number, limit: number, userId: string) {
+  async findAll(
+    page: number,
+    limit: number,
+    userId: string,
+    organizationId: string,
+  ) {
     const skip = (page - 1) * limit;
 
     const orgProjectsUsers = await this.OrganizationProjectUser.find({
       user: new Types.ObjectId(userId),
+      organization: new Types.ObjectId(organizationId),
     });
     // console.log(orgProjectsUsers);
     const projectIds = orgProjectsUsers.map((opu) => opu.project);
@@ -143,22 +184,8 @@ export class ProjectsService {
       data: result?.data || [],
     };
   }
-  async getNames(page: number, limit: number, userId: string) {
-    // console.log(organizations);
-    const orgProjectsUsers = await this.OrganizationProjectUser.find({
-      user: new Types.ObjectId(userId),
-    });
-    const projectIds = orgProjectsUsers.map((opu) => opu.project);
-    const projects = await this.projectModel.find({ _id: projectIds });
-    if (!projectIds || projectIds.length === 0) {
-      return [];
-    }
-    console.log(projects);
-    // Extract project names
-    return projects.map((project) => project['name']);
-  }
 
-  async getUserProjectsByOrganization(userId: string, organizationId: string) {
+  async getNames(userId: string, organizationId: string) {
     try {
       const userObjectId = new Types.ObjectId(userId);
       const orgObjectId = new Types.ObjectId(organizationId);
@@ -184,12 +211,12 @@ export class ProjectsService {
         {
           $replaceRoot: { newRoot: '$projectData' },
         },
-        // {
-        //   $project: {
-        //     _id: 1,
-        //     name: 1,
-        //   },
-        // },
+        {
+          $project: {
+            _id: 1,
+            name: 1,
+          },
+        },
       ]);
 
       return projects;
@@ -202,6 +229,51 @@ export class ProjectsService {
       );
     }
   }
+
+  // async getUserProjectsByOrganization(userId: string, organizationId: string) {
+  //   try {
+  //     const userObjectId = new Types.ObjectId(userId);
+  //     const orgObjectId = new Types.ObjectId(organizationId);
+
+  //     const projects = await this.OrganizationProjectUser.aggregate([
+  //       {
+  //         $match: {
+  //           user: userObjectId,
+  //           organization: orgObjectId,
+  //         },
+  //       },
+  //       {
+  //         $lookup: {
+  //           from: 'projects',
+  //           localField: 'project',
+  //           foreignField: '_id',
+  //           as: 'projectData',
+  //         },
+  //       },
+  //       {
+  //         $unwind: '$projectData',
+  //       },
+  //       {
+  //         $replaceRoot: { newRoot: '$projectData' },
+  //       },
+  //       // {
+  //       //   $project: {
+  //       //     _id: 1,
+  //       //     name: 1,
+  //       //   },
+  //       // },
+  //     ]);
+
+  //     return projects;
+  //   } catch (error) {
+  //     if (error instanceof BadRequestException) throw error;
+  //     if (error instanceof NotFoundException) throw error;
+  //     if (error instanceof UnauthorizedException) throw error;
+  //     throw new InternalServerErrorException(
+  //       'Failed to retrieve user projects',
+  //     );
+  //   }
+  // }
 
   /* istanbul ignore next */
   findOne(id: string) {


### PR DESCRIPTION
1. Removed '/projects/get-user-projects-by-organization' which is now implemented on the '/projects/names'

2. '/projects/names' now return an array of objects containing "_id" and "name"

3. '/projects/create' and '/projects/' now handles organization id